### PR TITLE
Loading YAML configuration should default to an empty hash

### DIFF
--- a/lib/dossier/configuration.rb
+++ b/lib/dossier/configuration.rb
@@ -17,6 +17,8 @@ module Dossier
 
     def yaml_config
       YAML.load(ERB.new(File.read(@config_path)).result)[Rails.env].symbolize_keys
+    rescue
+      {}
     end
    
     def dburl_config


### PR DESCRIPTION
Fix Heroku
